### PR TITLE
Feature/add openjdk11 support for ubuntu 16 04

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,19 +5,15 @@ galaxy_info:
   description: 'Manage Java OpenJRE/OpenJDK environment'
   company: 'DEVO Inc.'
   license: 'GPL-3.0'
-  min_ansible_version: '2.0.0'
+  min_ansible_version: '2.7'
   platforms:
+    - name: EL
+      versions:
+        - 7
     - name: Ubuntu
       versions:
-        - precise
-        - quantal
-        - raring
-        - saucy
-        - trusty
-    - name: Debian
-      versions:
-        - wheezy
-        - jessie
+        - 16.04
+        - 18.04
   galaxy_tags:
     - java
     - development

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -22,6 +22,10 @@ platforms:
     image: centos:7
     groups:
       - java-11
+  - name: ubuntu-16.04-java-11
+    image: ubuntu:16.04
+    groups:
+      - java-11
   - name: ubuntu-18.04-java-11
     image: ubuntu:18.04
     groups:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,8 +1,3 @@
-import os
-
-import testinfra.utils.ansible_runner
-
-
 def test_java_version(host):
     ansible_vars = host.ansible.get_variables()
     java_version = ansible_vars.get('java__version')

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,23 @@
         ansible_distribution == 'Red Hat Enterprise Linux' or
         ansible_distribution == 'RedHat'
 
+- name: Add openjdk11 repository and signing key for Ubuntu 16.04
+  block:
+    - name: Add openjdk11 repository for Ubuntu 16.04
+      apt_repository:
+        repo: deb http://ppa.launchpad.net/openjdk-r/ppa/ubuntu xenial main
+
+    - name: Add apt signing key
+      apt_key:
+        keyserver: keyserver.ubuntu.com
+        id: DA1A4A13543B466853BAF164EB9B1D8886F44E2A
+
+    - name: Update apt cache
+      apt:
+        update_cache: true
+  when: ansible_distribution_version == '16.04' and
+        java__version == 11
+
 - name: Install Java packages
   package:
     name: '{{ item }}'


### PR DESCRIPTION
Adds openjdk11 repository and signing key for Ubuntu 16.04
Corrects supported platforms and minimum ansible version in meta/main.yml
Removed 2 unused imports in testinfra test code